### PR TITLE
Generate script move to `./bin`

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 ROOT_PATH=$(cd $(dirname $0)/.. && pwd)
 
 docker run --rm -v ${ROOT_PATH}:/local openapitools/openapi-generator-cli:latest generate \

--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ROOT_PATH=$(cd $(dirname $0)/.. && pwd)
+
+docker run --rm -v ${ROOT_PATH}:/local openapitools/openapi-generator-cli:latest generate \
+    -DmodelTests=false -DapiTests=false \
+    -i https://api.shop-pro.jp/v1/swagger.json \
+    -g ruby \
+    -o /local/ \
+    --additional-properties moduleName=ColorMeShop,gemAuthor="GMO Pepabo inc.",gemHomepage=https://shop-pro.jp,gemLicense=MIT,gemDescription="カラーミーショップAPIのRubyクライアントです。",gemVersion=1.1.0


### PR DESCRIPTION
開発に関するスクリプトは `/bin` 配下に入れるのが流儀なので移動しました。

ref: https://bundler.io/blog/2015/03/20/moving-bins-to-exe.html